### PR TITLE
Add ASM6f support, closes #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Adds syntax highlighting to 65816/65C816/65802/6502/65C02 files in Atom, with ex
 
  - [ACME Crossassembler](https://sourceforge.net/projects/acme-crossass/)
  - [Asar SNES Assembler](https://github.com/RPGHacker/asar)
+ - [ASM6f](https://github.com/freem/asm6f) (support for NES emulator Mesen)
  - [cc65 (SNES Syntax: 65816, SPC700, SuperFX)](https://github.com/cc65/cc65)
  - [DASM](http://dasm-dillon.sourceforge.net/) (6502)
  - [EDASM](https://archive.org/details/EDASM-ProDOS_Assembler_Tools_Manual)

--- a/grammars/asm6.cson
+++ b/grammars/asm6.cson
@@ -1,7 +1,7 @@
 # Syntax Highlighting for the asm6 assembler
 
 scopeName: 'source.asm6'
-name: 'ASM6 (6502)'      # Name shown in Atom Editor grammar selection
+name: 'ASM6f (6502)'      # Name shown in Atom Editor grammar selection
 # File extensions associated with this grammar
 fileTypes: [
   's'
@@ -79,7 +79,7 @@ repository:
     patterns: [
       # ca65 pseudo variables
       {
-        match:  '(\\.)?\\b(?i:equ|include|incsrc|incbin|db|dw|byte|word|dcb|dcw|dc\\.b|dc\\.w)\\b'
+        match:  '(\\.)?\\b(?i:equ|include|incsrc|incbin|db|dw|byte|word|dcb|dcw|(dc\\.b)|(dc\\.w)|ignorenl|endinl|unstable|hunstable|inesprog|ineschr|inesmap|inesmir|nes2chrram|nes2prgram|nes2usb|nes2tv|nes2vs|nes2bram|nes2chrbram)\\b'
         name:   'support.function.pseudo.cc65-directives'
       }
       # ca65 pseudo functions
@@ -87,11 +87,6 @@ repository:
         match:  '(\\.)?\\b(?i:dl|dh|hex|dsb|dsw|pad|org|align|fillvalue|base|if|elseif|else|endif|ifdef|ifndef|macro|endm|rept|endr|enum|ende|error)\\b'
         name:   'support.function.pseudo.cc65-directives'
       }
-      # # CPU constants
-      # {
-      #   match:  '\\b(CPU_6502|CPU_65SC02|CPU_65C02|CPU_65816|CPU_SWEET16|CPU_HUC6280|CPU_ISET_6502|CPU_ISET_65SC02|CPU_ISET_65C02|CPU_ISET_65816|CPU_ISET_SWEET16|CPU_ISET_HUC6280|__APPLE2__|__APPLE2ENH__|__ATARI__|__ATARIXL__|__ATMOS__|__BBC__|__C128__|__C16__|__C64__|__CBM__|__CBM510__|__CBM610__|__GEOS__|__GEOS_APPLE__|__GEOS_CBM__|__LUNIX__|__LYNX__|__NES__|__PET__|__PLUS4__|__SIM6502__|__SIM65C02__|__SUPERVISION__|__VIC20__|VER_MAJOR|VER_MINOR)\\b'
-      #   name:   'constant.language.cc65-directives'
-      # }
       # address sizes, macpack packages
       # {
       #   match:  '\\b(?i:direct|zeropage|zp|absolute|abs|near|far|long|dword|atari|cbm|cpu|generic|longbranch)\\b'
@@ -99,12 +94,12 @@ repository:
       # }
       # Operators
       {
-        match:  '!|&|&&|\\^|\\*|\\/|\\-|\\+|~|=|<=|>=|<<|>>|<>|<|>|\\||\\|\\|'
+        match:  '!|&|&&|\\^|\\*|\\/|\\-|\\+|~|=|<=|>=|<<|>>|<>|<|>|\\||\\|\\|\\%'
         name:   'keyword.operator.cc65-directives'
       }
-      # Operators II
+      # Operators II/undocumented opcodes
       {
-        match:  '(\\.)\\b(?i:and|(bit)?(and|not|or|xor)|mod|shl|shr)\\b'
+        match:  '(\\.)\\b(?i:slo|rla|sre|rra|sax|lax|dcp|isc|anc|alr|arr|axs|las|ahx|shy|shx|tas|xaa)\\b'
         name:   'keyword.operator.cc65-directives'
       }
     ]

--- a/grammars/asm6.cson
+++ b/grammars/asm6.cson
@@ -5,6 +5,7 @@ name: 'ASM6f (6502)'      # Name shown in Atom Editor grammar selection
 # File extensions associated with this grammar
 fileTypes: [
   's'
+  'asm'
 ]
 patterns: [
   { include: 'source.65c02-opcodes' }   # extend with 6502X opcodes
@@ -79,12 +80,12 @@ repository:
     patterns: [
       # ca65 pseudo variables
       {
-        match:  '(\\.)?\\b(?i:equ|include|incsrc|incbin|db|dw|byte|word|dcb|dcw|(dc\\.b)|(dc\\.w)|ignorenl|endinl|unstable|hunstable|inesprog|ineschr|inesmap|inesmir|nes2chrram|nes2prgram|nes2usb|nes2tv|nes2vs|nes2bram|nes2chrbram)\\b'
+        match:  '(\\.)?\\b(?i:equ|include|incsrc|(inc)?bin|db|dw|byte|word|dcb|dcw|(dc\\.b)|(dc\\.w)|ignorenl|endinl|unstable|hunstable|inesprog|ineschr|inesmap|inesmir|nes2chrram|nes2prgram|nes2usb|nes2tv|nes2vs|nes2bram|nes2chrbram)\\b'
         name:   'support.function.pseudo.cc65-directives'
       }
       # ca65 pseudo functions
       {
-        match:  '(\\.)?\\b(?i:dl|dh|hex|dsb|dsw|pad|org|align|fillvalue|base|if|elseif|else|endif|ifdef|ifndef|macro|endm|rept|endr|enum|ende|error)\\b'
+        match:  '(\\.)?\\b(?i:dl|dh|hex|(ds\\.?b)|(ds\\.?w)|pad|org|align|fillvalue|base|if|elseif|else|endif|ifdef|ifndef|macro|endm|rept|endr|enum|ende|error)\\b'
         name:   'support.function.pseudo.cc65-directives'
       }
       # address sizes, macpack packages

--- a/grammars/asm6.cson
+++ b/grammars/asm6.cson
@@ -1,0 +1,110 @@
+# Syntax Highlighting for the asm6 assembler
+
+scopeName: 'source.asm6'
+name: 'ASM6 (6502)'      # Name shown in Atom Editor grammar selection
+# File extensions associated with this grammar
+fileTypes: [
+  's'
+]
+patterns: [
+  { include: 'source.65c02-opcodes' }   # extend with 6502X opcodes
+  { include: 'source.6502x-opcodes' }   # extend with 6502X opcodes
+  { include: '#comments' }  # comments
+  { include: '#symbols' }   # symbols, constants, numbers
+  { include: '#directives' } # cc65 assembler directives
+]
+
+# Repository starts here ------------------------------------------------------
+repository:
+
+  # comments
+  comments:
+    patterns: [
+      # semicolon comments
+      {
+        match:  ';.*$'
+        name:   'comment.line.semicolon.cc65-directives'
+      }
+    ]
+
+  # symbols
+  symbols:
+    patterns: [
+      # strings
+      {
+        begin: '[\"\']'
+        beginCaptures:
+          0:
+            name: 'punctuation.definition.string.begin.cc65-directives'
+        end: '[\"\']'
+        endCaptures:
+          0:
+            name: 'punctuation.definition.string.end.cc65-directives'
+        name: 'string.quoted.double.cc65-directives'
+      }
+      # absolut addressing/numbers
+      {
+        match: '\\#(\'.\'|[^\\s\']+)'
+        name: 'constant.numeric.hex.cc65-directives'
+      }
+      # hex, prefixed with dollar sign($)
+      {
+        match: '-?\\$\\b[a-fA-F0-9]+\\b'
+        name: 'constant.numeric.hex.cc65-directives'
+      }
+      # hex, suffixed with h(h)
+      {
+        match: '-?\\b([a-fA-F0-9]+)h\\b'
+        name: 'constant.numeric.hex.cc65-directives'
+      }
+      # binary prefixed with %
+      {
+        match: '%[01]+'
+        name: 'constant.numeric.binary.cc65-directives'
+      }
+      # binary suffixed with b
+      {
+        match: '[01]+[bB]'
+        name: 'constant.numeric.binary.cc65-directives'
+      }
+      # decimal
+      {
+        match: '\\b([0-9]+)\\b'
+        name: 'constant.numeric.decimal.cc65-directives'
+      }
+    ]
+
+  # assembler directives
+  directives:
+    patterns: [
+      # ca65 pseudo variables
+      {
+        match:  '(\\.)?\\b(?i:equ|include|incsrc|incbin|db|dw|byte|word|dcb|dcw|dc\\.b|dc\\.w)\\b'
+        name:   'support.function.pseudo.cc65-directives'
+      }
+      # ca65 pseudo functions
+      {
+        match:  '(\\.)?\\b(?i:dl|dh|hex|dsb|dsw|pad|org|align|fillvalue|base|if|elseif|else|endif|ifdef|ifndef|macro|endm|rept|endr|enum|ende|error)\\b'
+        name:   'support.function.pseudo.cc65-directives'
+      }
+      # # CPU constants
+      # {
+      #   match:  '\\b(CPU_6502|CPU_65SC02|CPU_65C02|CPU_65816|CPU_SWEET16|CPU_HUC6280|CPU_ISET_6502|CPU_ISET_65SC02|CPU_ISET_65C02|CPU_ISET_65816|CPU_ISET_SWEET16|CPU_ISET_HUC6280|__APPLE2__|__APPLE2ENH__|__ATARI__|__ATARIXL__|__ATMOS__|__BBC__|__C128__|__C16__|__C64__|__CBM__|__CBM510__|__CBM610__|__GEOS__|__GEOS_APPLE__|__GEOS_CBM__|__LUNIX__|__LYNX__|__NES__|__PET__|__PLUS4__|__SIM6502__|__SIM65C02__|__SUPERVISION__|__VIC20__|VER_MAJOR|VER_MINOR)\\b'
+      #   name:   'constant.language.cc65-directives'
+      # }
+      # address sizes, macpack packages
+      # {
+      #   match:  '\\b(?i:direct|zeropage|zp|absolute|abs|near|far|long|dword|atari|cbm|cpu|generic|longbranch)\\b'
+      #   name:   'constant.language.cc65-directives'
+      # }
+      # Operators
+      {
+        match:  '!|&|&&|\\^|\\*|\\/|\\-|\\+|~|=|<=|>=|<<|>>|<>|<|>|\\||\\|\\|'
+        name:   'keyword.operator.cc65-directives'
+      }
+      # Operators II
+      {
+        match:  '(\\.)\\b(?i:and|(bit)?(and|not|or|xor)|mod|shl|shr)\\b'
+        name:   'keyword.operator.cc65-directives'
+      }
+    ]


### PR DESCRIPTION
I found myself with an hour off, so I thought I'd do a quick fix and close #12. 

@MatthewCallis Do you mind if I push and publish new versions directly to this repository in the future? I started rewriting all grammars for the new tree-sitter parser, I'm just waiting for [this](https://github.com/atom/atom/issues/17029) to be fixed, then I can start replacing the old textMate grammars.