### PR TITLE
Fix operator regex for ACME grammar (again)

### DIFF
--- a/grammars/acme.cson
+++ b/grammars/acme.cson
@@ -124,8 +124,8 @@ repository:
       }
       # Operators
       {
-        match: '\!|\+|\-|\/|\|<<|>>|&|\||\^|=|<|>|\:'
-        name:   'keyword.operator'
+        match: '\\!|\\+|\\-|\\/|\\*|<<|>>|&|\\||\\^|=|<|>|\\:'
+        name:   'keyword.operator.acme'
       }
       # Operators II
       {


### PR DESCRIPTION
Currently, the regex causes the following error:

Uncaught Error: target of repeat operator is not specified

```
At /usr/lib/atom/node_modules/first-mate/lib/scanner.js:31

Error: target of repeat operator is not specified
    at Scanner.module.exports.Scanner.createScanner (/usr/lib/atom/node_modules/first-mate/lib/scanner.js:31:24)
    at Scanner.module.exports.Scanner.getScanner (/usr/lib/atom/node_modules/first-mate/lib/scanner.js:37:31)
    at Scanner.module.exports.Scanner.findNextMatch (/usr/lib/atom/node_modules/first-mate/lib/scanner.js:56:22)
    at Rule.module.exports.Rule.findNextMatch (/usr/lib/atom/node_modules/first-mate/lib/rule.js:98:28)
    at Rule.module.exports.Rule.getNextTags (/usr/lib/atom/node_modules/first-mate/lib/rule.js:154:21)
    at Grammar.module.exports.Grammar.tokenizeLine (/usr/lib/atom/node_modules/first-mate/lib/grammar.js:162:44)
    at TextMateLanguageMode.buildTokenizedLineForRowWithText (/usr/lib/atom/src/text-mate-language-mode.js:503:46)
    at TextMateLanguageMode.buildTokenizedLineForRow (/usr/lib/atom/src/text-mate-language-mode.js:488:17)
    at TextMateLanguageMode.tokenizeNextChunk (/usr/lib/atom/src/text-mate-language-mode.js:340:41)
    at _.defer (/usr/lib/atom/src/text-mate-language-mode.js:324:57)
    at /usr/lib/atom/node_modules/underscore/underscore.js:768:19
```

Fix the regex by applying the following modifications:
* use double backslashes to escape special characters
* insert missing * into regex

While here, also give the pattern a .acme suffix as all the other have.